### PR TITLE
Separate out Vpc stack from SharedInfraStack

### DIFF
--- a/bin/cross_stack_ecs_service.ts
+++ b/bin/cross_stack_ecs_service.ts
@@ -3,10 +3,18 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import { CrossStackEcsServiceStack } from '../lib/cross_stack_ecs_service-stack';
 import { SharedServiceStack } from '../lib/stacks/shared_service';
+import { VpcStack } from '../lib/stacks/vpc_stack';
 
 const app = new cdk.App();
 
-const sharedInfra = new SharedServiceStack(app, 'SharedInfraStack');
+//since Vpc Creation takes time, we would only need to do this once.
+const vpcStack = new VpcStack(app, 'VpcStack');
+
+
+//initialize and pass in vpcStack to the sharedInfra Stack to keep Vpc stack separate
+const sharedInfra = new SharedServiceStack(app, 'SharedInfraStack', {
+    vpc: vpcStack.vpc
+});
 
 
 new CrossStackEcsServiceStack(app, 'CrossStackEcsServiceStack', {

--- a/lib/stacks/shared_service.ts
+++ b/lib/stacks/shared_service.ts
@@ -9,14 +9,11 @@ export interface SharedServiceStackProps extends StackProps {
 }
 
 export class SharedServiceStack extends Stack {
-   
     public readonly cluster: ecs.Cluster;
 
     constructor(scope: Construct, id: string, props : SharedServiceStackProps) {
         super(scope, id, props);
 
-       
-        // create and initialize ecs Cluster.
         this.cluster = new ecs.Cluster(this, 'EcsCluster', {
           vpc: props.vpc
         });

--- a/lib/stacks/shared_service.ts
+++ b/lib/stacks/shared_service.ts
@@ -4,24 +4,26 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Construct } from "constructs";
 import { EcsConstruct } from "../constructs/ecs_constructs";
 
+export interface SharedServiceStackProps extends StackProps {
+    vpc: ec2.IVpc;
+}
 
 export class SharedServiceStack extends Stack {
-    public readonly vpc: ec2.Vpc;
+   
     public readonly cluster: ecs.Cluster;
 
-    constructor(scope: Construct, id: string, props : StackProps = {}) {
+    constructor(scope: Construct, id: string, props : SharedServiceStackProps) {
         super(scope, id, props);
 
-        this.vpc = new ec2.Vpc(this, 'Vpc', { 
-            maxAzs: 2 
-        });
+       
+        // create and initialize ecs Cluster.
         this.cluster = new ecs.Cluster(this, 'EcsCluster', {
-          vpc: this.vpc
+          vpc: props.vpc
         });
 
         
         const ecsConstruct = new EcsConstruct(this, 'ECSConstSharedServiceStack', {
-            vpc: this.vpc,
+            vpc: props.vpc,
             cluster: this.cluster,
         });
     }

--- a/lib/stacks/vpc_stack.ts
+++ b/lib/stacks/vpc_stack.ts
@@ -1,4 +1,4 @@
-import { Stack, StackProps } from "aws-cdk-lib/core/lib/stack";
+import { Stack, StackProps } from "aws-cdk-lib";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 

--- a/lib/stacks/vpc_stack.ts
+++ b/lib/stacks/vpc_stack.ts
@@ -1,0 +1,17 @@
+import { Stack, StackProps } from "aws-cdk-lib/core/lib/stack";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { Construct } from "constructs";
+
+
+export class VpcStack extends Stack {
+    public readonly vpc: ec2.IVpc;
+    constructor(scope: Construct, id: string, props: StackProps = {}) {
+        super(scope, 'VpcStack');
+
+         // create VPC 
+         this.vpc = new ec2.Vpc(this, 'Vpc', { 
+            maxAzs: 2 
+        });
+        
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cross_stack_ecs_service",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.66.1",
+        "aws-cdk-lib": "^2.66.1",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
       },
@@ -39,9 +39,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.86",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.86.tgz",
-      "integrity": "sha512-O9jRUV41sVRTL0Fw2ShiBy7pjsVIt7s/4Svo3XWZSGbPCVxPiE7jEu+dbve2PRuXTnoOX8dJrDhgGKYzUexL/A=="
+      "version": "2.2.88",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.88.tgz",
+      "integrity": "sha512-0A64KW2OIB1tGMx7uV7Vdc88G2WGIf0TIFYPH6bU+9tI5iB5Erw9Tu2Mo2w7lmMI0j7dRlMBtAXQMQkKEP1liA=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -3952,9 +3952,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.86",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.86.tgz",
-      "integrity": "sha512-O9jRUV41sVRTL0Fw2ShiBy7pjsVIt7s/4Svo3XWZSGbPCVxPiE7jEu+dbve2PRuXTnoOX8dJrDhgGKYzUexL/A=="
+      "version": "2.2.88",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.88.tgz",
+      "integrity": "sha512-0A64KW2OIB1tGMx7uV7Vdc88G2WGIf0TIFYPH6bU+9tI5iB5Erw9Tu2Mo2w7lmMI0j7dRlMBtAXQMQkKEP1liA=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "devDependencies": {
     "@types/jest": "^29.4.0",
     "@types/node": "18.13.0",
+    "aws-cdk": "2.66.1",
     "jest": "^29.4.2",
     "ts-jest": "^29.0.5",
-    "aws-cdk": "2.66.1",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.66.1",
+    "aws-cdk-lib": "^2.66.1",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"
   }


### PR DESCRIPTION
VpcStack creation takes quite sometime during CDK deployment. We would like to reduce this deployment time for each cdk update to this Ecs Project by separating out the vpcstack.